### PR TITLE
Add benchmarks for MEF and MEF2.

### DIFF
--- a/IoCBenchmark.sln
+++ b/IoCBenchmark.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IoCTestData", "IoCTestData\IoCTestData.csproj", "{5F184590-763D-4417-BA29-8B566312FD15}"
 EndProject
@@ -27,6 +27,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NinjectTest", "NinjectTest\NinjectTest.csproj", "{5FEAF1D7-CD41-449F-9C25-B4E0E196D14A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HiroTest", "HiroTest\HiroTest.csproj", "{DA16045F-96E8-4E4B-AC51-D165CE507036}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MefTest", "MefTest\MefTest.csproj", "{606A8F24-3C2E-48C3-BAEB-A47D6401308A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mef2Test", "Mef2Test\Mef2Test.csproj", "{839A8A1A-67D1-4023-B73C-DB4A9D3784B7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -74,6 +78,14 @@ Global
 		{DA16045F-96E8-4E4B-AC51-D165CE507036}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DA16045F-96E8-4E4B-AC51-D165CE507036}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DA16045F-96E8-4E4B-AC51-D165CE507036}.Release|Any CPU.Build.0 = Release|Any CPU
+		{606A8F24-3C2E-48C3-BAEB-A47D6401308A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{606A8F24-3C2E-48C3-BAEB-A47D6401308A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{606A8F24-3C2E-48C3-BAEB-A47D6401308A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{606A8F24-3C2E-48C3-BAEB-A47D6401308A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{839A8A1A-67D1-4023-B73C-DB4A9D3784B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{839A8A1A-67D1-4023-B73C-DB4A9D3784B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{839A8A1A-67D1-4023-B73C-DB4A9D3784B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{839A8A1A-67D1-4023-B73C-DB4A9D3784B7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -87,5 +99,7 @@ Global
 		{9E4707B8-DCBB-4F36-BD9F-7A0A676A72F7} = {5CF2D397-80BA-4DD3-BC27-8969E778081E}
 		{5FEAF1D7-CD41-449F-9C25-B4E0E196D14A} = {5CF2D397-80BA-4DD3-BC27-8969E778081E}
 		{DA16045F-96E8-4E4B-AC51-D165CE507036} = {5CF2D397-80BA-4DD3-BC27-8969E778081E}
+		{606A8F24-3C2E-48C3-BAEB-A47D6401308A} = {5CF2D397-80BA-4DD3-BC27-8969E778081E}
+		{839A8A1A-67D1-4023-B73C-DB4A9D3784B7} = {5CF2D397-80BA-4DD3-BC27-8969E778081E}
 	EndGlobalSection
 EndGlobal

--- a/Mef2Test/App.config
+++ b/Mef2Test/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/Mef2Test/Mef2Abstraction.cs
+++ b/Mef2Test/Mef2Abstraction.cs
@@ -1,0 +1,39 @@
+﻿using IoCBenchmark;
+using System.Composition.Convention;
+using System.Composition.Hosting;
+
+namespace Mef2Test
+{
+    public class Mef2Abstraction : IContainerAbstraction
+    {
+        private CompositionHost container;
+        private ConventionBuilder conventionBuilder = new ConventionBuilder();
+
+        public void Register<I, T>(bool singleton)
+            where I : class
+            where T : class, I
+        {
+            if (singleton)
+            {
+                conventionBuilder.ForType<T>().Export<I>().Shared();
+            }
+            else
+            {
+                conventionBuilder.ForType<T>().Export<I>();
+            }
+        }
+
+        public void Compile()
+        {
+            var configuration = new ContainerConfiguration().WithAssembly(typeof(TestRunner).Assembly, conventionBuilder);
+            container = configuration.CreateContainer();
+        }
+
+        public T Resolve<T>()
+            where T : class
+        {
+            var export = container.GetExport<T>();
+            return export;
+        }
+    }
+}

--- a/Mef2Test/Mef2Test.csproj
+++ b/Mef2Test/Mef2Test.csproj
@@ -1,0 +1,88 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{839A8A1A-67D1-4023-B73C-DB4A9D3784B7}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Mef2Test</RootNamespace>
+    <AssemblyName>Mef2Test</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Composition.AttributedModel, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Convention, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Hosting, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Runtime, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.TypedParts, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Mef2Abstraction.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\IoCTestData\IoCTestData.csproj">
+      <Project>{5f184590-763d-4417-ba29-8b566312fd15}</Project>
+      <Name>IoCTestData</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Mef2Test/Program.cs
+++ b/Mef2Test/Program.cs
@@ -1,0 +1,12 @@
+﻿using IoCBenchmark;
+
+namespace Mef2Test
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            new TestRunner().Run("Mef2", () => new Mef2Abstraction());
+        }
+    }
+}

--- a/Mef2Test/Properties/AssemblyInfo.cs
+++ b/Mef2Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Les informations générales relatives à un assembly dépendent de 
+// l'ensemble d'attributs suivant. Changez les valeurs de ces attributs pour modifier les informations
+// associées à un assembly.
+[assembly: AssemblyTitle("Mef2Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Mef2Test")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// L'affectation de la valeur false à ComVisible rend les types invisibles dans cet assembly 
+// aux composants COM.  Si vous devez accéder à un type dans cet assembly à partir de 
+// COM, affectez la valeur true à l'attribut ComVisible sur ce type.
+[assembly: ComVisible(false)]
+
+// Le GUID suivant est pour l'ID de la typelib si ce projet est exposé à COM
+[assembly: Guid("839a8a1a-67d1-4023-b73c-db4a9d3784b7")]
+
+// Les informations de version pour un assembly se composent des quatre valeurs suivantes :
+//
+//      Version principale
+//      Version secondaire 
+//      Numéro de build
+//      Révision
+//
+// Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
+// en utilisant '*', comme indiqué ci-dessous :
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Mef2Test/packages.config
+++ b/Mef2Test/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Composition" version="1.0.30" targetFramework="net452" />
+</packages>

--- a/MefTest/App.config
+++ b/MefTest/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/MefTest/MefAbstraction.cs
+++ b/MefTest/MefAbstraction.cs
@@ -1,0 +1,39 @@
+﻿using IoCBenchmark;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.ComponentModel.Composition.Registration;
+
+namespace Mef2Test
+{
+    public class MefAbstraction : IContainerAbstraction
+    {
+        private RegistrationBuilder registrationBuilder = new RegistrationBuilder();
+        private CompositionContainer container;
+
+        public void Register<I, T>(bool singleton)
+            where I : class
+            where T : class, I
+        {
+            if (singleton)
+            {
+                registrationBuilder.ForType<T>().Export<I>().SetCreationPolicy(CreationPolicy.Shared);
+            }
+            else
+            {
+                registrationBuilder.ForType<T>().Export<I>().SetCreationPolicy(CreationPolicy.NonShared);
+            }
+        }
+
+        public void Compile()
+        {
+            var catalog = new AssemblyCatalog(typeof(TestRunner).Assembly, registrationBuilder);
+            container = new CompositionContainer(catalog);
+        }
+
+        public T Resolve<T>()
+            where T : class
+        {
+            return container.GetExportedValue<T>();
+        }
+    }
+}

--- a/MefTest/MefTest.csproj
+++ b/MefTest/MefTest.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{606A8F24-3C2E-48C3-BAEB-A47D6401308A}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MefTest</RootNamespace>
+    <AssemblyName>MefTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.Composition.registration" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Reflection.Context" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Deployment" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MefAbstraction.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\IoCTestData\IoCTestData.csproj">
+      <Project>{5f184590-763d-4417-ba29-8b566312fd15}</Project>
+      <Name>IoCTestData</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/MefTest/Program.cs
+++ b/MefTest/Program.cs
@@ -1,0 +1,12 @@
+﻿using IoCBenchmark;
+
+namespace Mef2Test
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            new TestRunner().Run("Mef", () => new MefAbstraction());
+        }
+    }
+}

--- a/MefTest/Properties/AssemblyInfo.cs
+++ b/MefTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Les informations générales relatives à un assembly dépendent de 
+// l'ensemble d'attributs suivant. Changez les valeurs de ces attributs pour modifier les informations
+// associées à un assembly.
+[assembly: AssemblyTitle("MefTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MefTest")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// L'affectation de la valeur false à ComVisible rend les types invisibles dans cet assembly 
+// aux composants COM.  Si vous devez accéder à un type dans cet assembly à partir de 
+// COM, affectez la valeur true à l'attribut ComVisible sur ce type.
+[assembly: ComVisible(false)]
+
+// Le GUID suivant est pour l'ID de la typelib si ce projet est exposé à COM
+[assembly: Guid("606a8f24-3c2e-48c3-baeb-a47d6401308a")]
+
+// Les informations de version pour un assembly se composent des quatre valeurs suivantes :
+//
+//      Version principale
+//      Version secondaire 
+//      Numéro de build
+//      Révision
+//
+// Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
+// en utilisant '*', comme indiqué ci-dessous :
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TestAll/Program.cs
+++ b/TestAll/Program.cs
@@ -18,6 +18,8 @@ namespace TestAll
           //     RunProcess("HiroTest", build);
             //    RunProcess("DynamoTest", build);
             RunProcess("SimpleInjectorTest", build);
+            RunProcess("MefTest", build);
+            RunProcess("Mef2Test", build);
 
             Console.Read();
         }


### PR DESCRIPTION
Hello!

I really appreciated your blog entry at http://weareadaptive.com/blog/2014/11/04/net-ioc-container-performance/. The need for a benchmark with a large dependency graph indeed seems essential when the goal is to look at the performance for a real application containing thousands of classes.

I've been wanting to see how the 2 variants of MEF perform with this benchmark:
- MEF (included in .net 4.0)
- MEF2 (the so-called "Large throughput MEF", available as a Nuget package, see 
http://mef.codeplex.com/wikipage?title=What%20is%20Microsoft.Composition%3f&referringTitle=Documentation)

So this Pull Request adds 2 test projects using these 2 containers.

The results are interesting! On my machine (Core i3 laptop, Windows 10 64 bits), I get:

```
$ ./TestAll.exe
NinjectTest: 00:00:37.1590998
StructureMapTest: 00:00:03.6573611
AutofacTest: 00:00:06.9852654
CastleWindsorTest: 00:00:06.8291865
UnityTest: 00:00:05.9108391
SimpleInjectorTest: 00:01:11.4788259
MefTest: 00:00:59.6718514
Mef2Test: 00:00:01.7369103
```

So MEF included in .Net is very slow, roughly as bad as SimpleInjector.
However MEF2 looks like the big winner here! Twice faster than StructureMap!

(memory is also interesting here: MEF takes +300 MB, MEF2 only 31 MB, and Structure Map 34 MB).